### PR TITLE
Added Unit Type and Unit Term

### DIFF
--- a/Backend/FcTypeChecker.hs
+++ b/Backend/FcTypeChecker.hs
@@ -205,6 +205,7 @@ tcTerm (FcTmERROR s ty) = do
   unless (kind == KStar) $
     throwError "tcTerm: Kind mismatch (FcTmERROR)"
   return (FcTmERROR s ty, ty)
+tcTerm FcTmUnit = return (FcTmUnit, FcTyUnit)
 
 -- | Kind check a type
 tcType :: FcType -> FcM Kind
@@ -222,6 +223,7 @@ tcType (FcTyApp ty1 ty2) = do
     KArr k1a k1b | k1a == k2 -> return k1b
     _otherwise               -> throwError "tcType: Kind mismatch (FcTyApp)"
 tcType (FcTyCon tc) = lookupTyConKindM tc
+tcType FcTyUnit     = return KStar
 
 -- | Flatten out any or patterns in the alternatives
 -- flatAlts :: FcAlts 'Tc -> FcAlts 'Tc

--- a/Frontend/Conditions.hs
+++ b/Frontend/Conditions.hs
@@ -20,6 +20,7 @@ instance SizeOf (MonoTy a) where
   sizeOf (TyCon {})      = 1
   sizeOf (TyApp ty1 ty2) = sizeOf ty1 + sizeOf ty2
   sizeOf (TyVar {})      = 1
+  sizeOf TyUnit          = 1
 
 instance SizeOf (ClsCt a) where
   sizeOf (ClsCt _ ty) = sizeOf ty
@@ -35,6 +36,7 @@ instance Eq a => OccOf (HsTyVar a) (MonoTy a) where
   occOf _ (TyCon {})      = 0
   occOf a (TyApp ty1 ty2) = occOf a ty1 + occOf a ty2
   occOf a (TyVar b)       = if a == b then 1 else 0
+  occOf _ TyUnit          = 0
 
 instance Eq a => OccOf (HsTyVar a) (ClsCt a) where
   occOf a (ClsCt _cls ty) = occOf a ty
@@ -54,5 +56,3 @@ termCond (Ctr as cs ct) =  and [ sizeOf c < sizeOf ct | c <- cs ]
 -- | Unambiguous constraint
 unambigCtr :: Eq a => Ctr a -> Bool
 unambigCtr (Ctr as _ ct) = (map labelOf as) `subsetOf` ftyvsOf ct
-
-

--- a/Frontend/HsParser.hs
+++ b/Frontend/HsParser.hs
@@ -229,7 +229,8 @@ pTyVarWithKind = liftA2 (:|) pTyVar (symbol "::" *> pKind)
 
 -- | Parse a term (highest priority)
 pPrimTerm :: PsM PsTerm
-pPrimTerm  =  TmVar <$> pTmVar
+pPrimTerm  =  TmUnit <$ symbol "()"
+          <|> TmVar <$> pTmVar
           <|> TmCon <$> pDataCon
           <|> parens pTerm
 
@@ -255,8 +256,6 @@ pTerm  =  pAppTerm
           <*> pTerm
           <*  symbol "of"
           <*> some (indent pAlt)
-      <|> TmUnit
-          <$ symbol "()"
 
 -- Parse a primary parsed pattern (highest priority)
 pPrimPat :: PsM PsdPat

--- a/Frontend/HsParser.hs
+++ b/Frontend/HsParser.hs
@@ -255,6 +255,8 @@ pTerm  =  pAppTerm
           <*> pTerm
           <*  symbol "of"
           <*> some (indent pAlt)
+      <|> TmUnit
+          <$ symbol "()"
 
 -- Parse a primary parsed pattern (highest priority)
 pPrimPat :: PsM PsdPat

--- a/Frontend/HsRenamer.hs
+++ b/Frontend/HsRenamer.hs
@@ -158,6 +158,7 @@ rnMonoTy :: PsMonoTy -> RnM RnMonoTy
 rnMonoTy (TyCon tc)      = TyCon <$> lookupTyCon tc
 rnMonoTy (TyApp ty1 ty2) = TyApp <$> rnMonoTy ty1 <*> rnMonoTy ty2
 rnMonoTy (TyVar psa)     = TyVar <$> lookupTyVarM psa
+rnMonoTy TyUnit          = return TyUnit
 
 -- | Rename a qualified type
 rnQualTy :: PsQualTy -> RnM RnQualTy
@@ -216,6 +217,7 @@ rnTerm (TmLet x tm1 tm2)  = do
   rntm2 <- extendCtxTmM x rnx (rnTerm tm2)
   return (TmLet rnx rntm1 rntm2)
 rnTerm (TmCase scr alts)  = TmCase <$> rnTerm scr <*> mapM rnAlt alts
+rnTerm TmUnit             = return TmUnit
 
 -- | Rename a pattern
 rnPat :: PsPat -> RnM (RnPat, RnTmVarBinds)

--- a/Frontend/HsTypeChecker.hs
+++ b/Frontend/HsTypeChecker.hs
@@ -641,8 +641,8 @@ unify  untchs eqs
       = Just (mempty, [ty1 :~: ty3, ty2 :~: ty4])
     one_step _us (TyCon {} :~: TyApp {}) = Nothing
     one_step _us (TyApp {} :~: TyCon {}) = Nothing
-    one_step _us (_ :~: TyUnit) = Nothing
-    one_step _us (TyUnit :~: _) = Nothing
+    one_step _us (_ :~: TyUnit)          = Nothing
+    one_step _us (TyUnit :~: _)          = Nothing
 
     go :: (a -> Maybe b) -> [a] -> Maybe (b, [a])
     go _p []     = Nothing
@@ -654,7 +654,7 @@ occursCheck :: RnTyVar -> RnMonoTy -> Bool
 occursCheck _ (TyCon {})      = True
 occursCheck a (TyApp ty1 ty2) = occursCheck a ty1 && occursCheck a ty2
 occursCheck a (TyVar b)       = a /= b
-occursCheck _ TyUnit          = False
+occursCheck _ TyUnit          = True
 
 -- * Overlap Checking
 -- ------------------------------------------------------------------------------

--- a/Frontend/HsTypeChecker.hs
+++ b/Frontend/HsTypeChecker.hs
@@ -641,6 +641,7 @@ unify  untchs eqs
       = Just (mempty, [ty1 :~: ty3, ty2 :~: ty4])
     one_step _us (TyCon {} :~: TyApp {}) = Nothing
     one_step _us (TyApp {} :~: TyCon {}) = Nothing
+    one_step _us (TyUnit :~: TyUnit)     = Just (mempty, [])
     one_step _us (_ :~: TyUnit)          = Nothing
     one_step _us (TyUnit :~: _)          = Nothing
 

--- a/Tests/UnitTest.hs
+++ b/Tests/UnitTest.hs
@@ -1,3 +1,3 @@
 data Number = Succ Number | Zero
 
-\i. let f = \x. x in f ()
+\i. let f = \x.\y. y in f () Zero

--- a/Tests/UnitTest.hs
+++ b/Tests/UnitTest.hs
@@ -1,0 +1,3 @@
+data Number = Succ Number | Zero
+
+\i. let f = \x. x in f ()


### PR DESCRIPTION
Added both the Unit type `()` and the Unit term `()`. I wasn't sure which one I needed so I made both just in case.

Testable via:
`*Main> runTest "Tests/UnitTest.hs"`

Output:
```
---------------------------- Type Checked Program ---------------------------
data Number = Succ Number | Zero
/\t_uC.
  \(i_u4 :: t_uC).
    let f_u3 : () -> Number -> Number
             = \(x_u5 :: ()).
                 \(y_u6 :: Number).
                   y_u6
    in f_u3 () Zero
---------------------------- Elaborated Program ---------------------------
data Number = Succ Number | Zero
/\t_uC.
  \(i_u4 :: t_uC).
    let f_u3 : () -> Number -> Number
             = \(x_u5 :: ()).
                 \(y_u6 :: Number).
                   y_u6
    in f_u3 () Zero
Size: 125
------------------------------- Program Type ------------------------------
forall (t_uC : *). t_uC -> Number
------------------------------ Program Theory -----------------------------
{theory_super : [],
 theory_inst : [],
 theory_local : []}
-------------------------- System F Program Type --------------------------
forall t_uC. t_uC -> Number
```